### PR TITLE
Fixed location for openjdk location

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -15,6 +15,7 @@ RUN curl -sSL -o java.tar.gz "${URL}" && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/java /usr/bin/java && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javac /usr/bin/javac && \
 	sudo ln -s /usr/local/jdk-${JAVA_VERSION}/bin/javaws /usr/bin/javaws && \
+	sudo ln -s /usr/local/jdk-${JAVA_VERSION} /usr/local/openjdk-8 && \
 	# Install packages to help with legacy image migration
 	sudo apt-get update && sudo apt-get install -y \
 		fontconfig \


### PR DESCRIPTION
I require a fixed static location for the installation of the JDK as part of the build, i.e. if used within a maven toolchains.xml.
So create a symlink for /usr/local/openjdk-8 to the /usr/local/jdk-${JAVA_VERSION} so that toolchains.xml can just use /usr/local/openjdk-8.